### PR TITLE
fix(cropping):patch error with cropping on different crs

### DIFF
--- a/door/utils/geotiff.py
+++ b/door/utils/geotiff.py
@@ -20,9 +20,9 @@ def crop_raster(src: str|gdal.Dataset, BBox: BoundingBox, output_file: str) -> N
     geotransform = src_ds.GetGeoTransform()
 
     # transform the bounding box to the geotiff projection
-    BBox.transform(geoprojection)
+    BBox_trans = BBox.transform(geoprojection, inplace = False)
 
-    min_x, min_y, max_x, max_y = BBox.bbox
+    min_x, min_y, max_x, max_y = BBox_trans.bbox
     # in order to not change the grid, we need to make sure that the new bounds were also in the old grid
     in_min_x = geotransform[0]
     in_res_x = geotransform[1]

--- a/door/utils/space.py
+++ b/door/utils/space.py
@@ -69,7 +69,7 @@ class BoundingBox():
                      right + self.buffer,
                      top + self.buffer)
 
-    def transform(self, new_proj: str) -> None:
+    def transform(self, new_proj: str, inplace = False) -> None:
         """
         Transform the bounding box to a new projection
         """
@@ -106,8 +106,11 @@ class BoundingBox():
         else:
             min_x, min_y, max_x, max_y = self.bbox
 
-        self.bbox = (min_x, min_y, max_x, max_y)
-        self.proj = new_proj
+        if inplace:
+            self.bbox = (min_x, min_y, max_x, max_y)
+            self.proj = new_proj
+        else:
+            return BoundingBox(min_x, min_y, max_x, max_y, new_proj)
 
 
 def get_wkt(proj_string: str) -> str:


### PR DESCRIPTION
Previously the crop_raster function in utils/geotiff would modify the original bbox of the Space_ref when a transformation was needed, now we create a new one