### PR TITLE
fix(space): restructure space_reference object to handle WKT and EPSG better

### DIFF
--- a/door/utils/space.py
+++ b/door/utils/space.py
@@ -9,25 +9,24 @@ from osgeo import gdal, gdalconst, osr
 
 class BoundingBox():
 
-    default_projection = 'EPSG:4326'
+    default_datum = 'EPSG:4326'
     #'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]'
 
     def __init__(self,
                  left: float, bottom: float, right: float, top: float,
-                 projection: Optional[str] = None,
+                 datum: Optional[str] = None,
                  buffer: float = 0.0,):
         """
         Gets the CRS and bounding box of the grid file, this will be used to cut the data.
         No reprojection or resampling is done in DOOR.
         """
-        # default to WGS84
-        if projection is None:
-            self.epsg_code = self.default_projection
-        else:
-            self.epsg_code = projection
 
-        # set the projection
-        self.proj = get_wkt(self.epsg_code)
+        # datum should be able to accept both EPSG codes and WKT strings and should default to WGS84
+        if datum is None:
+            self.epsg_code = self.default_datum
+            self.wkt_datum = get_wkt(self.default_datum)
+        else:
+            self.epsg_code, self.wkt_datum = get_datum(datum)
 
         # set the bounding box
         self.bbox = (left, bottom, right, top)
@@ -56,7 +55,7 @@ class BoundingBox():
         proj  = grid_data.GetProjection()
 
         grid_data = None
-        return BoundingBox(left, bottom, right, top, projection = proj, buffer = buffer)
+        return BoundingBox(left, bottom, right, top, datum = proj, buffer = buffer)
 
     def buffer_bbox(self, buffer: int) -> None:
         """
@@ -69,24 +68,22 @@ class BoundingBox():
                      right + self.buffer,
                      top + self.buffer)
 
-    def transform(self, new_proj: str|int, inplace = False) -> None:
+    def transform(self, new_datum: str, inplace = False) -> None:
         """
-        Transform the bounding box to a new projection
-        new_proj: the new projection in the form of an EPSG code
+        Transform the bounding box to a new datum
+        new_datum: the new datum in the form of an EPSG code
         """
         
-        if isinstance(new_proj, int):
-            new_proj = f'EPSG:{new_proj}'
-        elif not new_proj.startswith('EPSG:'):
-            new_proj = 'EPSG:' + new_proj
+        # figure out if we were given an EPSG code or a WKT string
+        new_epsg, new_wkt = get_datum(new_datum)
 
         # Create a spatial reference object for the GeoTIFF projection
         new_srs = osr.SpatialReference()
-        new_srs.ImportFromWkt(get_wkt(new_proj))
+        new_srs.ImportFromWkt(new_wkt)
 
         # Create a spatial reference object for the bounding box projection
         bbox_srs = osr.SpatialReference()
-        bbox_srs.ImportFromWkt(self.proj)
+        bbox_srs.ImportFromWkt(self.wkt_datum)
         
         # this is needed to make sure that the axis are in the same order i.e. (lon, lat) or (x, y)
         # see https://gdal.org/tutorials/osr_api_tut.html#coordinate-systems-in-gdal
@@ -94,7 +91,7 @@ class BoundingBox():
         bbox_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 
         # make sure that the projection is the same, if it is not, update the 4 corners of the bbox
-        if not new_proj==self.epsg_code:
+        if not new_epsg==self.epsg_code:
 
             # Create a transformer to convert coordinates
             transformer = osr.CoordinateTransformation(bbox_srs, new_srs)
@@ -115,10 +112,10 @@ class BoundingBox():
 
         if inplace:
             self.bbox = (min_x, min_y, max_x, max_y)
-            self.proj = get_wkt(new_proj)
-            self.epsg_code = new_proj
+            self.wkt_datum = new_wkt
+            self.epsg_code = new_epsg
         else:
-            return BoundingBox(min_x, min_y, max_x, max_y, new_proj)
+            return BoundingBox(min_x, min_y, max_x, max_y, datum = new_epsg)
 
 
 def get_wkt(proj_string: str) -> str:
@@ -126,10 +123,7 @@ def get_wkt(proj_string: str) -> str:
     srs = osr.SpatialReference()
 
     # Import the EPSG code into the spatial reference object
-    try:
-        srs.ImportFromEPSG(int(proj_string.split(':')[1]))
-    except:
-        srs.ImportFromWkt(proj_string)
+    srs.ImportFromEPSG(int(proj_string.split(':')[1]))
 
     # Get the WKT string
     wkt_string = srs.ExportToWkt()
@@ -145,3 +139,20 @@ def get_epsg(wkt_string: str) -> str:
     epsg_code = srs.GetAuthorityCode(None)
 
     return f'EPSG:{epsg_code}'
+
+def get_datum(value: str) -> tuple[str]:
+    """
+    Check if the value is an EPSG code or a WKT string,
+    will return a tuple of (EPSG, WKT)
+    """
+    try: # this will fail if value it is not an EPSG code
+        epsg_code = value
+        wkt_datum = get_wkt(value)
+    except:
+        try: # this will fail if value is not a WKT string
+            wkt_datum = value
+            epsg_code = get_epsg(value)
+        except:
+            raise ValueError(f'Unknown datum type: {value}, please provide an EPSG code ("EPSG:#####") or a WKT string.')
+
+    return epsg_code, wkt_datum

--- a/workflow_examples/ecmwf_opendata_example.py
+++ b/workflow_examples/ecmwf_opendata_example.py
@@ -11,7 +11,7 @@ log_file = HOME+'/log.txt'
 log.set_logging(log_file, 'DEBUG')
 
 time_range = TimeRange(start='2024-02-06 00:00:00', end='2024-02-06 03:00:00')
-space_ref  = BoundingBox(6, 19, 36, 48, projection = 'EPSG:4326')
+space_ref  = BoundingBox(6, 19, 36, 48, datum = 'EPSG:4326')
 
 test_downloader = ECMWFOpenDataDownloader(product='HRES')
 test_downloader.get_data(time_range, space_ref,

--- a/workflow_examples/era5_example.py
+++ b/workflow_examples/era5_example.py
@@ -11,7 +11,7 @@ log_file = HOME+'/door-log.txt'
 log.set_logging(log_file, 'INFO')
 
 time_range = TimeRange(start='2024-04-01', end='2024-04-10 00:00:00')
-space_ref  = BoundingBox(-5.35,2.28,5.79,14.89, projection = 'EPSG:4326')
+space_ref  = BoundingBox(-5.35,2.28,5.79,14.89, datum = 'EPSG:4326')
 
 test_downloader = ERA5Downloader('reanalysis-era5-land')
 test_downloader.get_data(time_range, space_ref,

--- a/workflow_examples/grace_example.py
+++ b/workflow_examples/grace_example.py
@@ -10,7 +10,7 @@ log_file = HOME+'/log.txt'
 log.set_logging(log_file)
 
 time_range = TimeRange(start='2017-06-01', end='2018-06-30')
-space_ref  = BoundingBox(-18, -9, 18, 9, projection = 'EPSG:4326')
+space_ref  = BoundingBox(-18, -9, 18, 9, datum = 'EPSG:4326')
 
 test_downloader = GRACEDownloader('TWS')
 test_downloader.get_data(time_range, space_ref,

--- a/workflow_examples/icon_example.py
+++ b/workflow_examples/icon_example.py
@@ -14,7 +14,7 @@ log.set_logging(log_file, 'DEBUG')
 
 today = dt.datetime.now()
 time_range = TimeRange(start=f'{today:%Y-%m-%d 00:00:00}', end=f'{today:%Y-%m-%d 03:00:00}')
-space_ref  = BoundingBox(6, 19, 36, 48, projection = 'EPSG:4326')
+space_ref  = BoundingBox(6, 19, 36, 48, datum = 'EPSG:4326')
 
 test_downloader = ICONDownloader(product='ICON0p125')
 test_downloader.get_data(time_range, space_ref,

--- a/workflow_examples/viirs_example.py
+++ b/workflow_examples/viirs_example.py
@@ -10,7 +10,7 @@ log_file = HOME+'/log.txt'
 log.set_logging(log_file)
 
 time_range = TimeRange(start='2017-01-01', end='2017-02-12')
-space_ref  = BoundingBox(-5, -2, 5, 18, projection = 'EPSG:4326')
+space_ref  = BoundingBox(-5, -2, 5, 18, datum = 'EPSG:4326')
 
 test_downloader = VIIRSDownloader('FAPAR')
 test_downloader.get_data(time_range, space_ref,


### PR DESCRIPTION
C'era un po' di caos nella definizione del BOundingBox su come viene gestito il CRS (a volte con codice EPSG altre con stringa WKT).
Ho modificato il codice perché possa accettare entrambe le cose (sia nella creazione dell'oggetto che nel methodo di trasformazione).