### PR TITLE
fix(HSAF): ensure data has correct longitude range before cropping

### DIFF
--- a/door/utils/geotiff.py
+++ b/door/utils/geotiff.py
@@ -16,7 +16,9 @@ def crop_raster(src: str|gdal.Dataset, BBox: BoundingBox, output_file: str) -> N
         src_ds = gdal.Open(src, gdalconst.GA_ReadOnly)
     else:
         src_ds = src
-    
+
+    ## TODO: check the longitude values and transform them if necessary
+
     geoprojection = src_ds.GetProjection()
     geotransform = src_ds.GetGeoTransform()
 
@@ -62,6 +64,24 @@ def save_array_to_tiff(src: xr.DataArray, output_file:str) -> None:
     os.makedirs(os.path.dirname(output_file), exist_ok=True)
     src.rio.to_raster(output_file)
 
+# def transform_longitudes(dataset):
+#     # Get the original spatial reference
+#     old_srs = osr.SpatialReference()
+#     old_srs.ImportFromWkt(dataset.GetProjection())
+
+#     # Create a new spatial reference with a central meridian at 0
+#     new_srs = old_srs.Clone()
+#     new_srs.SetProjParm(osr.SRS_PP_CENTRAL_MERIDIAN, 0)
+
+
+#     # Apply the transformation to the dataset
+#     new_dataset = gdal.Warp('', dataset, format='MEM', dstSRS=new_srs,
+#                             outputBoundsSRS=new_srs,
+#                             xRes=dataset.GetGeoTransform()[1],
+#                             yRes=dataset.GetGeoTransform()[5],
+#                             dstNodata=dataset.GetRasterBand(1).GetNoDataValue())
+
+#     return new_dataset
 def transform_longitude(input_file:str) -> None:
     """
     Transform the longitude of a raster file from 0-360 to -180-180

--- a/door/utils/netcdf.py
+++ b/door/utils/netcdf.py
@@ -16,6 +16,14 @@ def crop_netcdf(src: str|xr.Dataset, BBox: BoundingBox) -> xr.DataArray:
     else:
         src_ds = src
 
+    x_dim = src_ds.rio.x_dim
+    lon_values = src_ds[x_dim].values
+    if (lon_values > 180).any():
+        new_lon_values = xr.where(lon_values > 180, lon_values - 360, lon_values)
+        new = src_ds.assign_coords({x_dim:new_lon_values}).sortby(x_dim)
+        src_ds = new.rio.set_spatial_dims(x_dim, new.rio.y_dim)
+
+
     # transform the bounding box to the geotiff projection
     if src_ds.rio.crs is not None:
         transformed_BBox = BBox.transform(src_ds.rio.crs.to_epsg())

--- a/door/utils/space.py
+++ b/door/utils/space.py
@@ -140,11 +140,14 @@ def get_epsg(wkt_string: str) -> str:
 
     return f'EPSG:{epsg_code}'
 
-def get_datum(value: str) -> tuple[str]:
+def get_datum(value: str|int) -> tuple[str]:
     """
     Check if the value is an EPSG code or a WKT string,
     will return a tuple of (EPSG, WKT)
     """
+    if isinstance(value, int):
+        value = f'EPSG:{value}'
+
     try: # this will fail if value it is not an EPSG code
         epsg_code = value
         wkt_datum = get_wkt(value)


### PR DESCRIPTION
HSAF data has longitudes encoded between 0:360 instead of -180:180. This will ensure the longitudes are corrected before cropping the files.
So far only implemented in xarray since this is a problem for HSAF that is processed with xarray. TODO also for gdal datasets