### PR TITLE
fix(era5): edit era5 to not import cfgrib until downloader is activates, to avoid eccodes dependency

### DIFF
--- a/door/data_sources/cds/era5_downloader.py
+++ b/door/data_sources/cds/era5_downloader.py
@@ -4,7 +4,6 @@ import tempfile
 import os
 import xarray as xr
 import numpy as np
-import cfgrib
 
 from .cds_downloader import CDSDownloader
 from ...utils.space import BoundingBox
@@ -153,6 +152,8 @@ class ERA5Downloader(CDSDownloader):
                        space_bounds: BoundingBox,
                        destination: str,
                        options: Optional[dict] = None) -> None:
+
+        import cfgrib
 
         # Check options
         options = self.check_options(options)


### PR DESCRIPTION
ERA5 downaloder depends on the cfgrib library, which requires ECCODES to be installed locally. moving the import inside the get_data function ensures that ECCODES are not required until the ERA5Downloader is imported (note from the __init__.py inside data_sources that ERA5 downlaoder is always impoted, even when not used.)